### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Compile the contracts with `pnpm build`.
 
 Run tests with `pnpm test`.
 
-Run coverage report with `pnpm coverage`. View coverage report with `genhtml -o report --branch-coverage --ignore-errors category lcov.info && py -m http.server`. Viewing the report with this command requires Python to be installed.
+Run coverage report with `pnpm coverage`. View coverage report with `genhtml -o report --branch-coverage --ignore-errors category lcov.info && python3 -m http.server`. Viewing the report with this command requires Python to be installed.
 
 Compare gas usage with `pnpm snapshot:compare`. Note as some test use random values, the gas usage may vary slightly between runs.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Compile the contracts with `pnpm build`.
 
 Run tests with `pnpm test`.
 
-Run coverage report with `yarn coverage`. View coverage report with `genhtml -o report --branch-coverage --ignore-errors category lcov.info && py -m http.server`. Viewing the report with this command requires Python to be installed.
+Run coverage report with `pnpm coverage`. View coverage report with `genhtml -o report --branch-coverage --ignore-errors category lcov.info && py -m http.server`. Viewing the report with this command requires Python to be installed.
 
-Compare gas usage with `yarn snapshot:compare`. Note as some test use random values, the gas usage may vary slightly between runs.
+Compare gas usage with `pnpm snapshot:compare`. Note as some test use random values, the gas usage may vary slightly between runs.
 
 ### Deployment
 


### PR DESCRIPTION
## Summary by Sourcery

Update README command instructions to use pnpm instead of yarn for coverage and gas snapshot comparisons

Documentation:
- Replace coverage report command from yarn to pnpm
- Replace gas usage snapshot comparison command from yarn to pnpm