### PR TITLE
Create yarn_ci.yml

### DIFF
--- a/.github/workflows/yarn_ci.yml
+++ b/.github/workflows/yarn_ci.yml
@@ -1,0 +1,105 @@
+on: [push]
+
+name: ci
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: Install dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - uses: actions/cache@master
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+      - run: yarn install --network-concurrency 1
+        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
+
+  lint-sol:
+    name: Solidity lint
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - uses: actions/cache@master
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run linting
+        run: yarn lint:sol
+
+  foundry-tests:
+    name: Foundry tests
+    runs-on: ubuntu-latest
+    needs: [install]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - uses: actions/cache@master
+        id: yarn-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run tests
+        run: FOUNDRY_FUZZ_RUNS=1024 forge test -vvv
+
+  # coverage:
+  #   name: Coverage
+  #   runs-on: ubuntu-latest
+  #   needs: [install]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 18
+  #     - uses: actions/cache@master
+  #       id: yarn-cache
+  #       with:
+  #         path: |
+  #           node_modules
+  #           */*/node_modules
+  #         key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
+  #     - run: yarn coverage || true
+  #     - name: Coveralls
+  #       uses: coverallsapp/github-action@master
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn_ci.yml
+++ b/.github/workflows/yarn_ci.yml
@@ -23,7 +23,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
-      - run: yarn install --network-concurrency 1
+      - run: yarn install
         if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
 
   lint-sol:


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions CI pipeline to install dependencies, lint Solidity code, and run Foundry tests on push

CI:
- Introduce a workflow with a cached Yarn install job
- Add a job to lint Solidity contracts using the Foundry toolchain
- Add a job to execute Foundry-based contract tests with fuzz runs
- Include a commented-out template for a coverage job