### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 on: [push]
 
 name: ci
+permissions:
+  contents: read
 
 jobs:
   install:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/contracts-library/security/code-scanning/4](https://github.com/Dargon789/contracts-library/security/code-scanning/4)

To fix this problem, you should explicitly add a `permissions:` block to your workflow, scoped as narrowly as possible. Since all jobs in this workflow do not appear to require write access to the repository (they only read code and run tests/linting), you can safely set `permissions:` at the workflow level to the minimal `contents: read`. This change mitigates the risk of the workflow having excessive permissions if the default for `GITHUB_TOKEN` is too permissive. To do this: insert a `permissions:` block with `contents: read` after the `name: ci` line, before listing jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
