### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: FOUNDRY_FUZZ_RUNS=1024 forge test -vvv
+        run: FOUNDRY_FUZZ_RUNS=1024 forge test --rerun -vvvvv
 
   # coverage:
   #   name: Coverage


### PR DESCRIPTION
## Summary by Sourcery

Enable test reruns on CI and increase verbosity of forge tests

CI:
- Add --rerun flag to forge test command in CI workflow
- Increase forge test verbosity level from -vvv to -vvvvv