### PR TITLE
Update npmjs workflow to support multiple branches

### DIFF
--- a/.github/workflows/npmjs.yml
+++ b/.github/workflows/npmjs.yml
@@ -12,5 +12,5 @@ jobs:
       - run: npm install -g corepack && corepack enable corepack use pnpm@10
       - run: pnpm install && pnpm build
       - run: pnpm config set npmAuthToken '${{ secrets.NPM_TOKEN }}'
-      - run: yarn publish --provenance --tolerate-republish
+      - run: pnpm publish --provenance --tolerate-republish
       


### PR DESCRIPTION
## Summary by Sourcery

Update the npm publishing workflow to run on multiple branches and adjust the install step before publishing.

Build:
- Allow the npm publish workflow to trigger on both main and master branches instead of only main.
- Change the build step to run yarn install prior to publishing to npm.