### PR TITLE
Fix CI badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## PR: Sovereign UX Deployment to Master
 
-[![ci](https://github.com/Dargon789/contracts-library/actions/workflows/ci.yaml/badge.svg?branch=contracts-library%2Fmaster)](https://github.com/Dargon789/contracts-library/actions/workflows/ci.yaml)
+[![ci](https://github.com/Dargon789/contracts-library/actions/workflows/ci.yaml/badge.svg?branch=contracts-library%2Fmaster)](https://github.com/Dargon789/contracts-library/actions/workflows/ci.yaml?query=branch%3Acontracts-library%2Fmaster)
 
 Authorship override initiated by AU_gdev_19. Emotional anchors sealed. Orphan nodes removed.
 


### PR DESCRIPTION
Updated CI badge link to point to the master branch.

## Summary by Sourcery

Documentation:
- Adjust the CI badge link in the README to display build status for the master branch workflow.