### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.defaultFormatter": "JuanBlanco.solidity"
   },
   "solidity.formatter": "forge",
-  "solidity.compileUsingRemoteVersion": "v0.8.30",
+  "solidity.compileUsingRemoteVersion": "v0.8.27",
   "solidity.remappings": [
     "openzeppelin-contracts/=lib/openzeppelin-contracts/",
     "openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/",


### PR DESCRIPTION
https://github.com/Dargon789/contracts-library/commit/095ae1f30f940361189c977806afefa54d6ddf27 remove  "erc2470-libs/=lib/erc2470-libs/",  non forge std

## Summary by Sourcery

Chores:
- Clean up editor settings by removing a non-standard erc2470-libs path mapping from .vscode/settings.json.