### PR TITLE
Update foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,16 +2,10 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-<<<<<<< Updated upstream
 solc = "0.8.19"
 solc-version = "0.8.19"
-=======
-solc = "0.8.27"
-solc-version = "0.8.27"
-evm_version = "paris"
->>>>>>> Stashed changes
 via_ir = true
-use_literal_content = true
+optimizer-runs = 20_000
 
 [profile.default.fuzz]
 runs = 1_024


### PR DESCRIPTION
## Summary by Sourcery

Adjust Foundry compiler configuration and optimization settings.

Build:
- Set Solidity compiler version to 0.8.19 in Foundry config and remove conflicting merge markers and EVM version setting.
- Replace literal content usage with an optimizer runs setting of 20,000 in Foundry configuration.