### PR TITLE
Add fuzz-seed option to test command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: FOUNDRY_FUZZ_RUNS=1024 forge test -vvv
+        run: FOUNDRY_FUZZ_RUNS=1024 forge test -vvv --fuzz-seed
 
   # coverage:
   #   name: Coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: FOUNDRY_FUZZ_RUNS=1024 forge test -vvv --fuzz-seed
+        run: FOUNDRY_FUZZ_RUNS=1024 forge test --fuzz-seed
 
   # coverage:
   #   name: Coverage


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure CI tests to run `forge test` with the `--fuzz-seed` option for reproducible fuzz runs.